### PR TITLE
Add comma support to features parameter regex

### DIFF
--- a/library/src/polyfill_parameters.rs
+++ b/library/src/polyfill_parameters.rs
@@ -32,7 +32,7 @@ pub fn get_polyfill_parameters(request: &worker::Request) -> PolyfillParameters 
     });
     let features = query
         .get("features")
-        .filter(|v| Regex::new(r"^[0-9a-zA-Z-_.@~]+$").unwrap().is_match(v))
+        .filter(|v| Regex::new(r"^[0-9a-zA-Z-_.@~,]+$").unwrap().is_match(v))
         .map_or_else(
             || "default".to_owned(),
             |f| decode(f).map_or_else(|_| f.to_string(), |f| f.to_string()),


### PR DESCRIPTION
## Problem
The regex validation for the `features` parameter was missing comma support, causing all multi-feature requests to fall back to "default".

## Example URLs affected:
- `?features=es2018,es2019,es2020,globalThis` → returned "default"
- `?features=Array.prototype.sort,globalThis` → returned "default"

## Root Cause
Regex pattern `^[0-9a-zA-Z-_.@~]+$` doesn't include commas, so the filter rejects any multi-feature string.

Resolves #19 